### PR TITLE
Test models against example metadata in spec

### DIFF
--- a/src/pydantic_ome_ngff/v04/imageLabel.py
+++ b/src/pydantic_ome_ngff/v04/imageLabel.py
@@ -34,7 +34,7 @@ class ImageLabel(VersionedBase):
     # SPEC: version is either unset or a string?
     version: Optional[str] = version
     colors: Optional[List[Color]]
-    properties: Optional[Properties]
+    properties: Optional[List[Properties]]
     source: Optional[Source]
 
     @validator("version")
@@ -55,7 +55,7 @@ class ImageLabel(VersionedBase):
             warnings.warn(
                 f"""
             The field "colors" is "None". Version {cls._version} of
-            the OME-NGFF spec states that "colors" should be a list of label 
+            the OME-NGFF spec states that "colors" should be a list of label
             descriptors.
             """
             )

--- a/src/pydantic_ome_ngff/v04/plate.py
+++ b/src/pydantic_ome_ngff/v04/plate.py
@@ -1,13 +1,13 @@
 from typing import List, Optional
 
-from pydantic import BaseModel, PositiveInt
+from pydantic import BaseModel, NonNegativeInt, PositiveInt
 from pydantic_ome_ngff.base import VersionedBase
 
 from pydantic_ome_ngff.v04.base import version
 
 
 class Acquisition(BaseModel):
-    id: PositiveInt
+    id: NonNegativeInt
     name: Optional[str]
     maximumfieldcount: PositiveInt
 
@@ -19,8 +19,8 @@ class Entry(BaseModel):
 class Well(BaseModel):
     # must be {rowName}/{columnName}
     path: str
-    rowIndex: PositiveInt
-    columnIndex: PositiveInt
+    rowIndex: NonNegativeInt
+    columnIndex: NonNegativeInt
 
 
 class Plate(VersionedBase):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,6 @@
-from typing import Tuple, Any
+import json
+from pathlib import Path
+from typing import Optional, Tuple, Any, Union
 import requests
 
 
@@ -13,3 +15,25 @@ def fetch_schemas(version: str, schema_name: str) -> Tuple[Any, Any]:
         f"https://ngff.openmicroscopy.org/{version}/schemas/{schema_name}.schema"
     ).json()
     return base_schema, strict_schema
+
+
+FIXTURE_DIR = Path(__file__).resolve().parent / "fixtures"
+
+Jso = Optional[Union[list["Jso"], dict[str, "Jso"], int, float, bool, str]]
+
+
+class JsonLoader:
+    def __init__(self, root: Union[str, Path]) -> None:
+        self.root = FIXTURE_DIR.joinpath(root)
+
+    def _path(self, path: Union[str, Path]) -> Path:
+        p = self.root.joinpath(path)
+        if not p.name.lower().endswith(".json"):
+            p = p.with_name(p.name + ".json")
+        return p
+
+    def load_str(self, path: Union[str, Path]) -> str:
+        return self._path(path).read_text()
+
+    def load_obj(self, path: Union[str, Path]) -> dict[str, Jso]:
+        return json.loads(self.load_str(path))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,6 @@
 import json
 from pathlib import Path
-from typing import Optional, Tuple, Any, Union
+from typing import Dict, List, Optional, Tuple, Any, Union
 import requests
 
 
@@ -19,7 +19,7 @@ def fetch_schemas(version: str, schema_name: str) -> Tuple[Any, Any]:
 
 FIXTURE_DIR = Path(__file__).resolve().parent / "fixtures"
 
-Jso = Optional[Union[list["Jso"], dict[str, "Jso"], int, float, bool, str]]
+Jso = Optional[Union[List["Jso"], Dict[str, "Jso"], int, float, bool, str]]
 
 
 class JsonLoader:

--- a/tests/fixtures/latest/image-label.json
+++ b/tests/fixtures/latest/image-label.json
@@ -1,0 +1,41 @@
+{
+  "image-label": {
+    "version": "0.5-dev",
+    "colors": [
+      {
+        "label-value": 0,
+        "rgba": [
+          0,
+          0,
+          128,
+          128
+        ]
+      },
+      {
+        "label-value": 1,
+        "rgba": [
+          0,
+          128,
+          0,
+          128
+        ]
+      }
+    ],
+    "properties": [
+      {
+        "label-value": 0,
+        "area (pixels)": 1200,
+        "class": "intercellular space"
+      },
+      {
+        "label-value": 1,
+        "area (pixels)": 1650,
+        "class": "cell",
+        "cell type": "neuron"
+      }
+    ],
+    "source": {
+      "image": "../../"
+    }
+  }
+}

--- a/tests/fixtures/latest/labels.json
+++ b/tests/fixtures/latest/labels.json
@@ -1,0 +1,5 @@
+{
+  "labels": [
+    "cell_space_segmentation"
+  ]
+}

--- a/tests/fixtures/latest/multiscales.json
+++ b/tests/fixtures/latest/multiscales.json
@@ -1,0 +1,103 @@
+{
+  "multiscales": [
+    {
+      "version": "0.5-dev",
+      "name": "example",
+      "axes": [
+        {
+          "name": "t",
+          "type": "time",
+          "unit": "millisecond"
+        },
+        {
+          "name": "c",
+          "type": "channel"
+        },
+        {
+          "name": "z",
+          "type": "space",
+          "unit": "micrometer"
+        },
+        {
+          "name": "y",
+          "type": "space",
+          "unit": "micrometer"
+        },
+        {
+          "name": "x",
+          "type": "space",
+          "unit": "micrometer"
+        }
+      ],
+      "datasets": [
+        {
+          "path": "0",
+          "coordinateTransformations": [
+            {
+              "type": "scale",
+              "scale": [
+                1.0,
+                1.0,
+                0.5,
+                0.5,
+                0.5
+              ]
+            }
+          ]
+        },
+        {
+          "path": "1",
+          "coordinateTransformations": [
+            {
+              "type": "scale",
+              "scale": [
+                1.0,
+                1.0,
+                1.0,
+                1.0,
+                1.0
+              ]
+            }
+          ]
+        },
+        {
+          "path": "2",
+          "coordinateTransformations": [
+            {
+              "type": "scale",
+              "scale": [
+                1.0,
+                1.0,
+                2.0,
+                2.0,
+                2.0
+              ]
+            }
+          ]
+        }
+      ],
+      "coordinateTransformations": [
+        {
+          "type": "scale",
+          "scale": [
+            0.1,
+            1.0,
+            1.0,
+            1.0,
+            1.0
+          ]
+        }
+      ],
+      "type": "gaussian",
+      "metadata": {
+        "description": "the fields in metadata depend on the downscaling implementation. Here, the parameters passed to the skimage function are given",
+        "method": "skimage.transform.pyramid_gaussian",
+        "version": "0.16.1",
+        "args": "[true]",
+        "kwargs": {
+          "multichannel": true
+        }
+      }
+    }
+  ]
+}

--- a/tests/fixtures/latest/plate0.json
+++ b/tests/fixtures/latest/plate0.json
@@ -1,0 +1,72 @@
+{
+  "plate": {
+    "acquisitions": [
+      {
+        "id": 1,
+        "maximumfieldcount": 2,
+        "name": "Meas_01(2012-07-31_10-41-12)",
+        "starttime": 1343731272000
+      },
+      {
+        "id": 2,
+        "maximumfieldcount": 2,
+        "name": "Meas_02(201207-31_11-56-41)",
+        "starttime": 1343735801000
+      }
+    ],
+    "columns": [
+      {
+        "name": "1"
+      },
+      {
+        "name": "2"
+      },
+      {
+        "name": "3"
+      }
+    ],
+    "field_count": 4,
+    "name": "test",
+    "rows": [
+      {
+        "name": "A"
+      },
+      {
+        "name": "B"
+      }
+    ],
+    "version": "0.5-dev",
+    "wells": [
+      {
+        "path": "A/1",
+        "rowIndex": 0,
+        "columnIndex": 0
+      },
+      {
+        "path": "A/2",
+        "rowIndex": 0,
+        "columnIndex": 1
+      },
+      {
+        "path": "A/3",
+        "rowIndex": 0,
+        "columnIndex": 2
+      },
+      {
+        "path": "B/1",
+        "rowIndex": 1,
+        "columnIndex": 0
+      },
+      {
+        "path": "B/2",
+        "rowIndex": 1,
+        "columnIndex": 1
+      },
+      {
+        "path": "B/3",
+        "rowIndex": 1,
+        "columnIndex": 2
+      }
+    ]
+  }
+}

--- a/tests/fixtures/latest/plate1.json
+++ b/tests/fixtures/latest/plate1.json
@@ -1,0 +1,91 @@
+{
+  "plate": {
+    "acquisitions": [
+      {
+        "id": 1,
+        "maximumfieldcount": 1,
+        "name": "single acquisition",
+        "starttime": 1343731272000
+      }
+    ],
+    "columns": [
+      {
+        "name": "1"
+      },
+      {
+        "name": "2"
+      },
+      {
+        "name": "3"
+      },
+      {
+        "name": "4"
+      },
+      {
+        "name": "5"
+      },
+      {
+        "name": "6"
+      },
+      {
+        "name": "7"
+      },
+      {
+        "name": "8"
+      },
+      {
+        "name": "9"
+      },
+      {
+        "name": "10"
+      },
+      {
+        "name": "11"
+      },
+      {
+        "name": "12"
+      }
+    ],
+    "field_count": 1,
+    "name": "sparse test",
+    "rows": [
+      {
+        "name": "A"
+      },
+      {
+        "name": "B"
+      },
+      {
+        "name": "C"
+      },
+      {
+        "name": "D"
+      },
+      {
+        "name": "E"
+      },
+      {
+        "name": "F"
+      },
+      {
+        "name": "G"
+      },
+      {
+        "name": "H"
+      }
+    ],
+    "version": "0.5-dev",
+    "wells": [
+      {
+        "path": "C/5",
+        "rowIndex": 2,
+        "columnIndex": 4
+      },
+      {
+        "path": "D/7",
+        "rowIndex": 3,
+        "columnIndex": 6
+      }
+    ]
+  }
+}

--- a/tests/fixtures/latest/well0.json
+++ b/tests/fixtures/latest/well0.json
@@ -1,0 +1,23 @@
+{
+  "well": {
+    "images": [
+      {
+        "acquisition": 1,
+        "path": "0"
+      },
+      {
+        "acquisition": 1,
+        "path": "1"
+      },
+      {
+        "acquisition": 2,
+        "path": "2"
+      },
+      {
+        "acquisition": 2,
+        "path": "3"
+      }
+    ],
+    "version": "0.5-dev"
+  }
+}

--- a/tests/fixtures/latest/well1.json
+++ b/tests/fixtures/latest/well1.json
@@ -1,0 +1,15 @@
+{
+  "well": {
+    "images": [
+      {
+        "acquisition": 0,
+        "path": "0"
+      },
+      {
+        "acquisition": 3,
+        "path": "1"
+      }
+    ],
+    "version": "0.5-dev"
+  }
+}

--- a/tests/fixtures/v04/image-label.json
+++ b/tests/fixtures/v04/image-label.json
@@ -1,0 +1,39 @@
+{
+  "image-label": {
+    "version": "0.4",
+    "colors": [
+      {
+        "label-value": 1,
+        "rgba": [
+          255,
+          255,
+          255,
+          255
+        ]
+      },
+      {
+        "label-value": 4,
+        "rgba": [
+          0,
+          255,
+          255,
+          128
+        ]
+      }
+    ],
+    "properties": [
+      {
+        "label-value": 1,
+        "area (pixels)": 1200,
+        "class": "foo"
+      },
+      {
+        "label-value": 4,
+        "area (pixels)": 1650
+      }
+    ],
+    "source": {
+      "image": "../../"
+    }
+  }
+}

--- a/tests/fixtures/v04/multiscales.json
+++ b/tests/fixtures/v04/multiscales.json
@@ -1,0 +1,103 @@
+{
+  "multiscales": [
+    {
+      "version": "0.4",
+      "name": "example",
+      "axes": [
+        {
+          "name": "t",
+          "type": "time",
+          "unit": "millisecond"
+        },
+        {
+          "name": "c",
+          "type": "channel"
+        },
+        {
+          "name": "z",
+          "type": "space",
+          "unit": "micrometer"
+        },
+        {
+          "name": "y",
+          "type": "space",
+          "unit": "micrometer"
+        },
+        {
+          "name": "x",
+          "type": "space",
+          "unit": "micrometer"
+        }
+      ],
+      "datasets": [
+        {
+          "path": "0",
+          "coordinateTransformations": [
+            {
+              "type": "scale",
+              "scale": [
+                1.0,
+                1.0,
+                0.5,
+                0.5,
+                0.5
+              ]
+            }
+          ]
+        },
+        {
+          "path": "1",
+          "coordinateTransformations": [
+            {
+              "type": "scale",
+              "scale": [
+                1.0,
+                1.0,
+                1.0,
+                1.0,
+                1.0
+              ]
+            }
+          ]
+        },
+        {
+          "path": "2",
+          "coordinateTransformations": [
+            {
+              "type": "scale",
+              "scale": [
+                1.0,
+                1.0,
+                2.0,
+                2.0,
+                2.0
+              ]
+            }
+          ]
+        }
+      ],
+      "coordinateTransformations": [
+        {
+          "type": "scale",
+          "scale": [
+            0.1,
+            1.0,
+            1.0,
+            1.0,
+            1.0
+          ]
+        }
+      ],
+      "type": "gaussian",
+      "metadata": {
+        "description": "the fields in metadata depend on the downscaling implementation. Here, the parameters passed to the skimage function are given",
+        "method": "skimage.transform.pyramid_gaussian",
+        "version": "0.16.1",
+        "args": "[true]",
+        "kwargs": {
+          "multichannel": true
+        }
+      }
+    }
+  ]
+}

--- a/tests/fixtures/v04/plate0.json
+++ b/tests/fixtures/v04/plate0.json
@@ -1,0 +1,72 @@
+{
+  "plate": {
+    "acquisitions": [
+      {
+        "id": 1,
+        "maximumfieldcount": 2,
+        "name": "Meas_01(2012-07-31_10-41-12)",
+        "starttime": 1343731272000
+      },
+      {
+        "id": 2,
+        "maximumfieldcount": 2,
+        "name": "Meas_02(201207-31_11-56-41)",
+        "starttime": 1343735801000
+      }
+    ],
+    "columns": [
+      {
+        "name": "1"
+      },
+      {
+        "name": "2"
+      },
+      {
+        "name": "3"
+      }
+    ],
+    "field_count": 4,
+    "name": "test",
+    "rows": [
+      {
+        "name": "A"
+      },
+      {
+        "name": "B"
+      }
+    ],
+    "version": "0.4",
+    "wells": [
+      {
+        "path": "A/1",
+        "rowIndex": 0,
+        "columnIndex": 0
+      },
+      {
+        "path": "A/2",
+        "rowIndex": 0,
+        "columnIndex": 1
+      },
+      {
+        "path": "A/3",
+        "rowIndex": 0,
+        "columnIndex": 2
+      },
+      {
+        "path": "B/1",
+        "rowIndex": 1,
+        "columnIndex": 0
+      },
+      {
+        "path": "B/2",
+        "rowIndex": 1,
+        "columnIndex": 1
+      },
+      {
+        "path": "B/3",
+        "rowIndex": 1,
+        "columnIndex": 2
+      }
+    ]
+  }
+}

--- a/tests/fixtures/v04/plate1.json
+++ b/tests/fixtures/v04/plate1.json
@@ -1,0 +1,91 @@
+{
+  "plate": {
+    "acquisitions": [
+      {
+        "id": 1,
+        "maximumfieldcount": 1,
+        "name": "single acquisition",
+        "starttime": 1343731272000
+      }
+    ],
+    "columns": [
+      {
+        "name": "1"
+      },
+      {
+        "name": "2"
+      },
+      {
+        "name": "3"
+      },
+      {
+        "name": "4"
+      },
+      {
+        "name": "5"
+      },
+      {
+        "name": "6"
+      },
+      {
+        "name": "7"
+      },
+      {
+        "name": "8"
+      },
+      {
+        "name": "9"
+      },
+      {
+        "name": "10"
+      },
+      {
+        "name": "11"
+      },
+      {
+        "name": "12"
+      }
+    ],
+    "field_count": 1,
+    "name": "sparse test",
+    "rows": [
+      {
+        "name": "A"
+      },
+      {
+        "name": "B"
+      },
+      {
+        "name": "C"
+      },
+      {
+        "name": "D"
+      },
+      {
+        "name": "E"
+      },
+      {
+        "name": "F"
+      },
+      {
+        "name": "G"
+      },
+      {
+        "name": "H"
+      }
+    ],
+    "version": "0.4",
+    "wells": [
+      {
+        "path": "C/5",
+        "rowIndex": 2,
+        "columnIndex": 4
+      },
+      {
+        "path": "D/7",
+        "rowIndex": 3,
+        "columnIndex": 6
+      }
+    ]
+  }
+}

--- a/tests/fixtures/v04/well0.json
+++ b/tests/fixtures/v04/well0.json
@@ -1,0 +1,23 @@
+{
+  "well": {
+    "images": [
+      {
+        "acquisition": 1,
+        "path": "0"
+      },
+      {
+        "acquisition": 1,
+        "path": "1"
+      },
+      {
+        "acquisition": 2,
+        "path": "2"
+      },
+      {
+        "acquisition": 2,
+        "path": "3"
+      }
+    ],
+    "version": "0.4"
+  }
+}

--- a/tests/fixtures/v04/well1.json
+++ b/tests/fixtures/v04/well1.json
@@ -1,0 +1,15 @@
+{
+  "well": {
+    "images": [
+      {
+        "acquisition": 0,
+        "path": "0"
+      },
+      {
+        "acquisition": 3,
+        "path": "1"
+      }
+    ],
+    "version": "0.4"
+  }
+}

--- a/tests/test_v04.py
+++ b/tests/test_v04.py
@@ -1,11 +1,15 @@
-from typing import Tuple, List, Optional
+from typing import Tuple, List, Optional, Type
 import jsonschema as jsc
 import pytest
-from pydantic import ValidationError
+from pydantic import ValidationError, BaseModel
 from pydantic_ome_ngff.tree import Array
-from .conftest import fetch_schemas
+from pydantic_ome_ngff.v04.imageLabel import ImageLabel
+from pydantic_ome_ngff.v04.plate import Plate
+from pydantic_ome_ngff.v04.well import Well
+from .conftest import JsonLoader, fetch_schemas
 from pydantic_ome_ngff.v04.multiscales import (
     Multiscale,
+    MultiscaleAttrs,
     MultiscaleDataset,
     MultiscaleGroup,
 )
@@ -15,6 +19,8 @@ from pydantic_ome_ngff.v04.coordinateTransformations import (
     VectorTranslationTransform,
 )
 from pydantic_ome_ngff.v04.axes import Axis
+
+loader = JsonLoader("v04")
 
 
 @pytest.fixture
@@ -339,3 +345,25 @@ def test_multiscale_group_datasets_rank(default_multiscale: Multiscale):
             attrs={"multiscales": [default_multiscale.dict()]},
             children=bad_children,
         )
+
+
+@pytest.mark.parametrize(
+    ("fname", "key", "Class"),
+    [
+        ("image-label", "image-label", ImageLabel),
+        ("plate0", "plate", Plate),
+        ("plate1", "plate", Plate),
+        ("well0", "well", Well),
+        ("well1", "well", Well),
+        (
+            "multiscales",
+            None,
+            MultiscaleAttrs,
+        ),
+    ],
+)
+def test_examples(fname: str, key: str, Class: Type[BaseModel]):
+    obj = loader.load_obj(fname)
+    if key is not None:
+        obj = obj[key]
+    Class.parse_obj(obj)


### PR DESCRIPTION
These won't exercise all possible validations but they're a good way of making sure it's broadly in sync. Found a couple of bugs too!

There are comments in some of the JSON blocks in the spec, which had to come out, and my editor jumped on autoformatting them too, so they look a bit different but the content is the same.

There currently isn't an equivalent to the `MultiscaleAttrs` class for other metadata types (probably not too much of a problem). There also isn't a class mirroring the `labels.json` metadata object (although it is trivial).