### PR TITLE
feat: add validatable collections objects for transforms and axes

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -700,14 +700,14 @@ files = [
 
 [[package]]
 name = "typing-extensions"
-version = "4.5.0"
+version = "4.7.1"
 description = "Backported and Experimental Type Hints for Python 3.7+"
 category = "main"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "typing_extensions-4.5.0-py3-none-any.whl", hash = "sha256:fb33085c39dd998ac16d1431ebc293a8b3eedd00fd4a32de0ff79002c19511b4"},
-    {file = "typing_extensions-4.5.0.tar.gz", hash = "sha256:5cb5f4a79139d699607b3ef622a1dedafa84e115ab0024e0d9c044a9479ca7cb"},
+    {file = "typing_extensions-4.7.1-py3-none-any.whl", hash = "sha256:440d5dd3af93b060174bf433bccd69b0babc3b15b1a8dca43789fd7f61514b36"},
+    {file = "typing_extensions-4.7.1.tar.gz", hash = "sha256:b75ddc264f0ba5615db7ba217daeb99701ad295353c45f9e95963337ceeeffb2"},
 ]
 
 [[package]]

--- a/src/pydantic_ome_ngff/v04/coordinateTransformations.py
+++ b/src/pydantic_ome_ngff/v04/coordinateTransformations.py
@@ -1,4 +1,5 @@
-from typing import List, Literal, Union
+from typing import Any, Iterable, List, Literal, Union
+
 from pydantic_ome_ngff.base import StrictBase
 
 
@@ -10,6 +11,11 @@ class IdentityTransform(StrictBase):
 
     # SPEC why does this exist, as opposed to translation by 0 or scale by 1?
     type: str = "identity"
+
+    @property
+    def ndim(self):
+        msg = "Cannot get the dimensionality of an identity transform."
+        raise NotImplementedError(msg)
 
 
 class PathTransform(StrictBase):
@@ -25,6 +31,11 @@ class PathTransform(StrictBase):
     type: Union[Literal["scale"], Literal["translation"]]
     path: str
 
+    @property
+    def ndim(self):
+        msg = "Cannot get the dimensionality of a transform with a path parameter."
+        raise NotImplementedError(msg)
+
 
 class VectorTranslationTransform(StrictBase):
     """
@@ -37,6 +48,10 @@ class VectorTranslationTransform(StrictBase):
         float
     ]  # SPEC: redundant field name -- we already know it's translation
 
+    @property
+    def ndim(self) -> int:
+        return len(self.translation)
+
 
 class VectorScaleTransform(StrictBase):
     """
@@ -47,26 +62,108 @@ class VectorScaleTransform(StrictBase):
     type: Literal["scale"] = "scale"
     scale: List[float]  # SPEC: redundant field name -- we already know it's scale
 
-
-def get_transform_ndim(
-    transform: Union[VectorScaleTransform, VectorTranslationTransform]
-) -> int:
-    """
-    Get the dimensionality of a vector transform (scale or translation).
-    """
-    if transform.type == "scale" and hasattr(transform, "scale"):
-        return len(transform.scale)
-    elif transform.type == "translation" and hasattr(transform, "translation"):
-        return len(transform.translation)
-    else:
-        raise ValueError(
-            f"""
-        Transform must be either VectorScaleTransform or VectorTranslationTransform.
-        Got {type(transform)} instead.
-        """
-        )
+    @property
+    def ndim(self) -> int:
+        return len(self.scale)
 
 
 ScaleTransform = Union[VectorScaleTransform, PathTransform]
 TranslationTransform = Union[VectorTranslationTransform, PathTransform]
 CoordinateTransform = Union[ScaleTransform, TranslationTransform, IdentityTransform]
+
+
+def _transform_from_dict(transform: dict[str, Any]) -> CoordinateTransform:
+    """
+    Convert a CoordinateTransform from a dict into the respective pydantic model.
+    There is almost certainly a better way to do this.
+    """
+    errs = []
+    for typ in CoordinateTransform.__args__:
+        try:
+            return typ.parse_obj(transform)
+        except ValueError as e:
+            errs.append(e)
+    raise ValueError(f"Could not parse {transform} as a CoordinateTransform")
+
+
+def check_transform_order(
+    transforms: Iterable[CoordinateTransform],
+) -> list[CoordinateTransform]:
+    tforms = list(transforms)
+    num_tforms = len(tforms)
+
+    # check that transforms are in the correct order.
+    if num_tforms > 0 and (tform := tforms[0].type) != "scale":
+        msg = (
+            "The first element of coordinateTransformations must be a scale "
+            f"transform. Got {tform} instead."
+        )
+        raise ValueError(msg)
+
+    if num_tforms == 2:
+        if (tform := transforms[1].type) != "translation":
+            msg = (
+                "The second element of coordinateTransformations must be a "
+                f"translation transform. Got {tform} instead."
+            )
+            raise ValueError(msg)
+
+    elif num_tforms > 2:
+        msg = (
+            f"Too many coordinateTransformations (got {num_tforms}). At most "
+            "two coordinateTransformations are allowed."
+        )
+        raise ValueError(msg)
+
+    return tforms
+
+
+def check_transform_ndims(
+    transforms: Iterable[CoordinateTransform],
+) -> list[CoordinateTransform]:
+    tforms = list(transforms)
+    # check that dimensionality is consistent
+    ndims: list[int] = []
+    for tx in tforms:
+        try:
+            ndims.append(tx.ndim)
+        except NotImplementedError:
+            continue
+
+    if len(set(ndims)) > 1:
+        msg = (
+            "Elements of coordinateTransformations must have the same "
+            f"dimensionality. Got elements with dimensionality = {ndims}."
+        )
+        raise ValueError(msg)
+
+    return tforms
+
+
+class Transforms(list[CoordinateTransform]):
+    """
+    A list of coordinateTransforms that can be validated by pydantic.
+    """
+
+    @classmethod
+    def __get_validators__(cls):
+        yield cls.validate
+
+    @classmethod
+    def validate(cls, v):
+        tforms = []
+        for tform in v:
+            if isinstance(tform, dict):
+                tforms.append(_transform_from_dict(tform))
+            else:
+                tforms.append(tform)
+        tforms = check_transform_ndims(tforms)
+        tforms = check_transform_order(tforms)
+        return cls(tforms)
+
+    @property
+    def ndim(self):
+        if len(self) > 0:
+            return self[0].ndim
+        else:
+            return 1


### PR DESCRIPTION
This PR adds `Transforms` and `Axes` classes. The goal is to encapsulate the validation routines that require checking collections of axis / coordinateTransforms objects for consistency, e.g. ensuring that coordinateTransformations have consistent dimensionality, or ensuring that axes don't have duplicate names.

The new classes subclass `list[CoordinateTransformations]` and `list[Axis]` respectively, and add some pydantic machinery as per the pydantic [docs on field classes](https://docs.pydantic.dev/1.10/usage/types/#custom-data-types). I'm not _super_ happy with the results, because I feel like the collection should be validated on `__init__`, but I couldn't get that to work without some ugly code duplication. This is likely due to my incompetence rather than some deep technical barrier.

Because I didn't feel great about the work here, I only implemented this for v04. If we think this is an OK approach, I will go ahead and copy this stuff over to 0.5-dev.

cc @clbarnes