### PR TITLE
Don't refer to the `path` attribute for Zarr stores

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,13 @@
-from typing import Any
+from __future__ import annotations
+from typing import TYPE_CHECKING
 
+if TYPE_CHECKING:
+    from typing import Any
+
+import pytest
 import requests
+from zarr.storage import MemoryStore, FSStore, NestedDirectoryStore
+import py
 
 
 def fetch_schemas(version: str, schema_name: str) -> tuple[Any, Any]:
@@ -14,3 +21,18 @@ def fetch_schemas(version: str, schema_name: str) -> tuple[Any, Any]:
         f"https://ngff.openmicroscopy.org/{version}/schemas/{schema_name}.schema"
     ).json()
     return base_schema, strict_schema
+
+
+@pytest.fixture(scope="function")
+def memory_store() -> MemoryStore:
+    return MemoryStore()
+
+
+@pytest.fixture(scope="function")
+def fsstore_local(tmpdir: py.path.local) -> FSStore:
+    return FSStore(str(tmpdir))
+
+
+@pytest.fixture(scope="function")
+def nested_directory_store(tmpdir: py.path.local) -> NestedDirectoryStore:
+    return NestedDirectoryStore(tmpdir)

--- a/tests/v04/test_multiscales.py
+++ b/tests/v04/test_multiscales.py
@@ -31,15 +31,15 @@ import operator
 
 @pytest.fixture
 def default_multiscale() -> MultiscaleMetadata:
-    axes = [
+    axes = (
         Axis(name="c", type="channel", unit=None),
         Axis(name="z", type="space", unit="meter"),
         Axis(name="x", type="space", unit="meter"),
         Axis(name="y", type="space", unit="meter"),
-    ]
+    )
     rank = len(axes)
     num_datasets = 3
-    datasets = [
+    datasets = tuple(
         Dataset(
             path=f"path{idx}",
             coordinateTransformations=(
@@ -48,7 +48,7 @@ def default_multiscale() -> MultiscaleMetadata:
             ),
         )
         for idx in range(num_datasets)
-    ]
+    )
 
     multi = MultiscaleMetadata(
         name="foo",

--- a/tests/v04/test_multiscales.py
+++ b/tests/v04/test_multiscales.py
@@ -1,10 +1,15 @@
 from __future__ import annotations
-from typing import Dict, Literal, Tuple
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import Dict, Literal, Tuple
+    from zarr.storage import MemoryStore, NestedDirectoryStore, FSStore
+
 from pydantic import ValidationError
 import pytest
 import jsonschema as jsc
 from zarr.util import guess_chunks
-from pydantic_zarr.v2 import ArraySpec
+from pydantic_zarr.v2 import ArraySpec, GroupSpec
 from pydantic_ome_ngff.v04.multiscale import (
     MultiscaleMetadata,
     GroupAttrs,
@@ -38,18 +43,8 @@ def default_multiscale() -> MultiscaleMetadata:
         Dataset(
             path=f"path{idx}",
             coordinateTransformations=(
-                VectorScale(
-                    scale=[
-                        1,
-                    ]
-                    * rank
-                ),
-                VectorTranslation(
-                    translation=[
-                        0,
-                    ]
-                    * rank
-                ),
+                VectorScale(scale=(1,) * rank),
+                VectorTranslation(translation=(0,) * rank),
             ),
         )
         for idx in range(num_datasets)
@@ -59,14 +54,7 @@ def default_multiscale() -> MultiscaleMetadata:
         name="foo",
         axes=axes,
         datasets=datasets,
-        coordinateTransformations=(
-            VectorScale(
-                scale=[
-                    1,
-                ]
-                * rank
-            ),
-        ),
+        coordinateTransformations=(VectorScale(scale=(1,) * rank),),
     )
     return multi
 
@@ -79,51 +67,51 @@ def test_multiscale(default_multiscale: MultiscaleMetadata) -> None:
 
 
 def test_multiscale_unique_axis_names() -> None:
-    axes = [
+    axes = (
         Axis(name="y", type="space", unit="meter"),
         Axis(name="x", type="space", unit="meter"),
-    ]
+    )
 
     # this should be fine
 
-    datasets = [
+    datasets = (
         Dataset(
             path="path",
             coordinateTransformations=(
-                VectorScale(scale=[1, 1, 1]),
-                VectorTranslation(translation=[0, 0, 0]),
+                VectorScale(scale=(1, 1, 1)),
+                VectorTranslation(translation=(0, 0, 0)),
             ),
-        )
-    ]
+        ),
+    )
 
     MultiscaleMetadata(
         name="foo",
         axes=axes,
         datasets=datasets,
-        coordinateTransformations=(VectorScale(scale=[1, 1, 1]),),
+        coordinateTransformations=(VectorScale(scale=(1, 1, 1)),),
     )
 
     # make axis names collide
-    axes = [
+    axes = (
         Axis(name="x", type="space", unit="meter"),
         Axis(name="x", type="space", unit="meter"),
-    ]
-    datasets = [
+    )
+    datasets = (
         Dataset(
             path="path",
             coordinateTransformations=(
-                VectorScale(scale=[1, 1]),
-                VectorTranslation(translation=[0, 0]),
+                VectorScale(scale=(1, 1)),
+                VectorTranslation(translation=(0, 0)),
             ),
-        )
-    ]
+        ),
+    )
 
     with pytest.raises(ValidationError, match="Axis names must be unique."):
         MultiscaleMetadata(
             name="foo",
             axes=axes,
             datasets=datasets,
-            coordinateTransformations=(VectorScale(scale=[1, 1]),),
+            coordinateTransformations=(VectorScale(scale=(1, 1)),),
         )
 
 
@@ -136,83 +124,51 @@ def test_multiscale_unique_axis_names() -> None:
 )
 def test_multiscale_space_axes_last(axis_types: list[str | None]) -> None:
     units_map = {"space": "meter", "time": "second"}
-    axes = [
+    axes = tuple(
         Axis(name=str(idx), type=t, unit=units_map.get(t, None))
         for idx, t in enumerate(axis_types)
-    ]
+    )
     rank = len(axes)
-    datasets = [
+    datasets = (
         Dataset(
             path="path",
             coordinateTransformations=(
-                VectorScale(
-                    scale=[
-                        1,
-                    ]
-                    * rank
-                ),
-                VectorTranslation(
-                    translation=[
-                        0,
-                    ]
-                    * rank
-                ),
+                VectorScale(scale=(1,) * rank),
+                VectorTranslation(translation=(0,) * rank),
             ),
-        )
-    ]
+        ),
+    )
     # TODO: make some axis-specifc exceptions
     with pytest.raises(ValidationError, match="Space axes must come last."):
         MultiscaleMetadata(
             name="foo",
             axes=axes,
             datasets=datasets,
-            coordinateTransformations=(
-                VectorScale(
-                    scale=[
-                        1,
-                    ]
-                    * rank
-                ),
-            ),
+            coordinateTransformations=(VectorScale(scale=(1,) * rank),),
         )
 
 
 @pytest.mark.parametrize("num_axes", [0, 1, 6, 7])
 def test_multiscale_axis_length(num_axes: int) -> None:
     rank = num_axes
-    axes = [Axis(name=str(idx), type="space", unit="meter") for idx in range(num_axes)]
-    datasets = [
+    axes = tuple(
+        Axis(name=str(idx), type="space", unit="meter") for idx in range(num_axes)
+    )
+    datasets = (
         Dataset(
             path="path",
             coordinateTransformations=(
-                VectorScale(
-                    scale=[
-                        1,
-                    ]
-                    * rank
-                ),
-                VectorTranslation(
-                    translation=[
-                        0,
-                    ]
-                    * rank
-                ),
+                VectorScale(scale=(1,) * rank),
+                VectorTranslation(translation=(0,) * rank),
             ),
-        )
-    ]
+        ),
+    )
     with pytest.raises(ValidationError, match="Incorrect number of axes provided"):
         MultiscaleMetadata(
             name="foo",
             axes=axes,
             datasets=datasets,
-            coordinateTransformations=(
-                VectorScale(
-                    scale=[
-                        1,
-                    ]
-                    * rank
-                ),
-            ),
+            coordinateTransformations=(VectorScale(scale=(1,) * rank),),
         )
 
 
@@ -222,10 +178,10 @@ def test_multiscale_axis_length(num_axes: int) -> None:
 def test_transform_invalid_ndims(
     scale: tuple[int, ...], translation: tuple[int, ...]
 ) -> None:
-    tforms = [
+    tforms = (
         VectorScale(scale=scale),
         VectorTranslation(translation=translation),
-    ]
+    )
     with pytest.raises(
         ValidationError,
         match="The transforms have inconsistent dimensionality.",
@@ -236,19 +192,16 @@ def test_transform_invalid_ndims(
 @pytest.mark.parametrize(
     "transforms",
     [
-        [
+        (
             VectorScale(scale=(1, 1, 1)),
             VectorTranslation(translation=(1, 1, 1)),
             VectorTranslation(translation=(1, 1, 1)),
-        ],
-        [
-            VectorScale(scale=(1, 1, 1)),
-        ]
-        * 5,
+        ),
+        (VectorScale(scale=(1, 1, 1)),) * 5,
     ],
 )
 def test_transform_invalid_length(
-    transforms: list[Transform],
+    transforms: tuple[Transform, ...],
 ) -> None:
     with pytest.raises(
         ValidationError, match=f"after validation, not {len(transforms)}"
@@ -259,14 +212,11 @@ def test_transform_invalid_length(
 @pytest.mark.parametrize(
     "transforms",
     [
-        [
-            VectorTranslation(translation=(1, 1, 1)),
-        ]
-        * 2,
-        [
+        (VectorTranslation(translation=(1, 1, 1)),) * 2,
+        (
             VectorTranslation(translation=(1, 1, 1)),
             VectorScale(scale=(1, 1, 1)),
-        ],
+        ),
     ],
 )
 def test_transform_invalid_first_element(
@@ -282,10 +232,10 @@ def test_transform_invalid_first_element(
 @pytest.mark.parametrize(
     "transforms",
     (
-        [
+        (
             VectorScale(scale=(1, 1, 1)),
             VectorScale(scale=(1, 1, 1)),
-        ],
+        ),
     ),
 )
 def test_transform_invalid_second_element(
@@ -301,7 +251,7 @@ def test_transform_invalid_second_element(
 def test_multiscale_group_datasets_exist(
     default_multiscale: MultiscaleMetadata,
 ) -> None:
-    group_attrs = GroupAttrs(multiscales=[default_multiscale])
+    group_attrs = GroupAttrs(multiscales=(default_multiscale,))
     good_items = {
         d.path: ArraySpec(
             shape=(1, 1, 1, 1),
@@ -337,7 +287,7 @@ def test_multiscale_group_datasets_exist(
 
 
 def test_multiscale_group_datasets_rank(default_multiscale: MultiscaleMetadata) -> None:
-    group_attrs = GroupAttrs(multiscales=[default_multiscale])
+    group_attrs = GroupAttrs(multiscales=(default_multiscale,))
     good_items = {
         d.path: ArraySpec(
             shape=(1, 1, 1, 1),
@@ -400,31 +350,33 @@ def test_from_arrays(
     chunks: Literal["auto", "tuple", "tuple-of-tuple"],
     order: Literal["auto", "C", "F"],
 ) -> None:
-    arrays = [np.arange(x**ndim).reshape((x,) * ndim) for x in [3, 2, 1]]
-    paths = [path_pattern.format(idx) for idx in range(len(arrays))]
-    scales = [(2**idx,) * ndim for idx in range(len(arrays))]
-    translations = [
+    arrays = tuple(np.arange(x**ndim).reshape((x,) * ndim) for x in [3, 2, 1])
+    paths = tuple(path_pattern.format(idx) for idx in range(len(arrays)))
+    scales = tuple((2**idx,) * ndim for idx in range(len(arrays)))
+    translations = tuple(
         (t,) * ndim
         for t in accumulate(
             [(2 ** (idx - 1)) for idx in range(len(arrays))], operator.add
         )
-    ]
+    )
 
-    all_axes = [
-        Axis(
-            name="x",
-            type="space",
-        ),
-        Axis(name="y", type="space"),
-        Axis(name="z", type="space"),
-        Axis(name="t", type="time"),
-        Axis(name="c", type="barf"),
-    ]
+    all_axes = tuple(
+        [
+            Axis(
+                name="x",
+                type="space",
+            ),
+            Axis(name="y", type="space"),
+            Axis(name="z", type="space"),
+            Axis(name="t", type="time"),
+            Axis(name="c", type="barf"),
+        ]
+    )
     # spatial axes have to come last
     if ndim in (2, 3):
         axes = all_axes[:ndim]
     else:
-        axes = [*all_axes[4:], *all_axes[:3]]
+        axes = tuple([*all_axes[4:], *all_axes[:3]])
 
     if chunks == "auto":
         chunks_arg = chunks
@@ -475,3 +427,61 @@ def test_from_arrays(
             VectorScale(scale=scales[idx]),
             VectorTranslation(translation=translations[idx]),
         )
+
+
+@pytest.mark.parametrize(
+    "store_type", ["memory_store", "fsstore_local", "nested_directory_store"]
+)
+def test_from_zarr_missing_metadata(
+    store_type: Literal["memory_store", "fsstore_local", "nested_directory_store"],
+    request: pytest.FixtureRequest,
+) -> None:
+    store: MemoryStore | NestedDirectoryStore | FSStore = request.getfixturevalue(
+        store_type
+    )
+    group_model = GroupSpec()
+    group = group_model.to_zarr(store, path="test")
+    with pytest.raises(ValueError):
+        Group.from_zarr(group)
+
+
+@pytest.mark.parametrize(
+    "store_type", ["memory_store", "fsstore_local", "nested_directory_store"]
+)
+def test_from_zarr_missing_array(
+    store_type: Literal["memory_store", "fsstore_local", "nested_directory_store"],
+    request: pytest.FixtureRequest,
+) -> None:
+    store: MemoryStore | NestedDirectoryStore | FSStore = request.getfixturevalue(
+        store_type
+    )
+    arrays = np.zeros((10, 10)), np.zeros((5, 5))
+    group_path = "broken"
+    arrays_names = ("s0", "s1")
+    group_model = Group.from_arrays(
+        arrays=arrays,
+        axes=(Axis(name="x", type="space"), Axis(name="y", type="space")),
+        paths=arrays_names,
+        scales=((1, 1), (2, 2)),
+        translations=((0, 0), (0.5, 0.5)),
+    )
+
+    # make an untyped model, and remove an array before serializing
+    removed_array_path = arrays_names[0]
+    model_dict = group_model.model_dump(exclude={"members": {removed_array_path: True}})
+    broken_group = GroupSpec(**model_dict).to_zarr(store=store, path=group_path)
+    match = (
+        f"Expected to find an array at {group_path}/{removed_array_path}, "
+        "but no array was found there."
+    )
+    with pytest.raises(ValueError, match=match):
+        Group.from_zarr(broken_group)
+
+    # put a group where the array should be
+    broken_group.create_group(removed_array_path)
+    match = (
+        f"Expected to find an array at {group_path}/{removed_array_path}, "
+        "but a group was found there instead."
+    )
+    with pytest.raises(ValueError, match=match):
+        Group.from_zarr(broken_group)


### PR DESCRIPTION
In `main`, an exception message refers to the `path` attribute of a Zarr store, but for `zarr.storage.MemoryStore` there is no `path` attribute. Not great that the Zarr store API is ... textured like this. This PR fixes this by changing the error message, and adds tests for the expected behavior. I also took some liberty to tweak type hints, and convert some lists to tuples in the tests.