### PR TITLE
raise a keyerror when multiscales metadata is missing from attributes

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -38,7 +38,7 @@ import zarr
 url = "https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.4/idr0062A/6001240.zarr"
 
 # open the Zarr group
-zgroup = zarr.open(url)
+zgroup = zarr.open(url, mode='r')
 
 # group_model is a `GroupSpec`, i.e. a Pydantic model of a Zarr group
 group_model = Group.from_zarr(zgroup)
@@ -113,7 +113,7 @@ print(multi_meta)
 arrays = [zgroup[d.path] for d in multi_meta[0].datasets]
 print(arrays)
 """
-[<zarr.core.Array '/0' (2, 236, 275, 271) uint16>, <zarr.core.Array '/1' (2, 236, 137, 135) uint16>, <zarr.core.Array '/2' (2, 236, 68, 67) uint16>]
+[<zarr.core.Array '/0' (2, 236, 275, 271) uint16 read-only>, <zarr.core.Array '/1' (2, 236, 137, 135) uint16 read-only>, <zarr.core.Array '/2' (2, 236, 68, 67) uint16 read-only>]
 """
 ```
 

--- a/src/pydantic_ome_ngff/utils.py
+++ b/src/pydantic_ome_ngff/utils.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from collections import Counter
 from typing import TYPE_CHECKING, Protocol, runtime_checkable
+from zarr.storage import BaseStore
 
 import numpy as np
 
@@ -38,3 +39,14 @@ def listify_numpy(data: Any) -> Any:
     if isinstance(data, np.ndarray):
         return data.tolist()
     return data
+
+
+def get_path(store: BaseStore) -> str:
+    """
+    Get a path from a zarr store
+    """
+    if hasattr(store, "path"):
+        return store.path
+
+    else:
+        return ""

--- a/tests/v04/test_multiscales.py
+++ b/tests/v04/test_multiscales.py
@@ -377,7 +377,7 @@ def test_from_arrays(
         axes = all_axes[:ndim]
     else:
         axes = tuple([*all_axes[4:], *all_axes[:3]])
-
+    chunks_arg: tuple[tuple[int, ...], ...] | tuple[int, ...] | Literal["auto"]
     if chunks == "auto":
         chunks_arg = chunks
         chunks_expected = (
@@ -441,7 +441,12 @@ def test_from_zarr_missing_metadata(
     )
     group_model = GroupSpec()
     group = group_model.to_zarr(store, path="test")
-    with pytest.raises(ValueError):
+    store_path = store.path if hasattr(store, "path") else ""
+    match = (
+        "Failed to find mandatory `multiscales` key in the attributes of the Zarr group at "
+        f"{store}://{store_path}://{group.path}."
+    )
+    with pytest.raises(KeyError, match=match):
         Group.from_zarr(group)
 
 


### PR DESCRIPTION
in `main` missing `multiscales` metadata results in a `ValueError`, which is not correct given that `KeyError` exists. This PR ensures that `KeyError` gets raised in this case.  I also changed `Group.from_zarr` to not traverse the entire hierarchy when guessing members. 

This is a performance optimization to avoid too many calls to remote stores, but it also means that a multiscale group will only ever contain sub-arrays and sub-groups that are declared explicitly in the `multiscales` metadata.