### PR TITLE
rename `Group` and `Groupattrs` to `MultiscaleGroup` and `MultiscaleGroupAttrs`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,6 @@ authors = [
 classifiers = [
   "Development Status :: 4 - Beta",
   "Programming Language :: Python",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",

--- a/src/pydantic_ome_ngff/latest/multiscale.py
+++ b/src/pydantic_ome_ngff/latest/multiscale.py
@@ -33,14 +33,14 @@ class MultiscaleMetadata(msv04.MultiscaleMetadata):
     version: Literal["0.5-dev"] = version
 
 
-class GroupAttrs(msv04.GroupAttrs):
+class GroupAttrs(msv04.MultiscaleGroupAttrs):
     """
     Attributes of a multiscale group.
     See https://ngff.openmicroscopy.org/latest/#multiscale-md
     """
 
 
-class Group(msv04.Group):
+class Group(msv04.MultiscaleGroup):
     """
     A model of a Zarr group that implements OME-NGFF Multiscales metadata, version 0.5-dev.
 

--- a/src/pydantic_ome_ngff/v04/__init__.py
+++ b/src/pydantic_ome_ngff/v04/__init__.py
@@ -1,7 +1,11 @@
 from pydantic_ome_ngff.v04.axis import Axis
 from pydantic_ome_ngff.v04.base import version
 from pydantic_ome_ngff.v04.label import ImageLabel
-from pydantic_ome_ngff.v04.multiscale import MultiscaleMetadata
+from pydantic_ome_ngff.v04.multiscale import (
+    MultiscaleMetadata,
+    MultiscaleGroup,
+    MultiscaleGroupAttrs,
+)
 from pydantic_ome_ngff.v04.plate import PlateMetadata
 from pydantic_ome_ngff.v04.transform import Transform
 from pydantic_ome_ngff.v04.well import WellMetadata
@@ -9,6 +13,8 @@ from pydantic_ome_ngff.v04.well import WellMetadata
 __all__ = [
     "Axis",
     "Transform",
+    "MultiscaleGroup",
+    "MultiscaleGroupAttrs",
     "MultiscaleMetadata",
     "ImageLabel",
     "WellMetadata",

--- a/src/pydantic_ome_ngff/v04/label.py
+++ b/src/pydantic_ome_ngff/v04/label.py
@@ -102,7 +102,7 @@ class ImageLabel(VersionedBase):
         return parse_imagelabel(self)
 
 
-class GroupAttrs(multiscale.GroupAttrs):
+class GroupAttrs(multiscale.MultiscaleGroupAttrs):
     """
     Attributes for a Zarr group that contains `image-label` metadata.
     Inherits from `v04.multiscales.MultiscaleAttrs`.
@@ -120,5 +120,5 @@ class GroupAttrs(multiscale.GroupAttrs):
     image_label: Annotated[ImageLabel, Field(..., serialization_alias="image-label")]
 
 
-class Group(multiscale.Group):
+class Group(multiscale.MultiscaleGroup):
     attributes: GroupAttrs

--- a/src/pydantic_ome_ngff/v04/multiscale.py
+++ b/src/pydantic_ome_ngff/v04/multiscale.py
@@ -4,7 +4,7 @@ from collections import Counter
 from typing import TYPE_CHECKING
 
 import numpy as np
-from typing_extensions import Literal
+from typing_extensions import Literal, deprecated
 
 if TYPE_CHECKING:
     from numcodecs.abc import Codec
@@ -20,7 +20,7 @@ from zarr.errors import ArrayNotFoundError, ContainsGroupError
 from zarr.util import guess_chunks
 
 import pydantic_ome_ngff.v04.transform as tx
-from pydantic_ome_ngff.base import StrictBase, StrictVersionedBase
+from pydantic_ome_ngff.base import StrictBase, VersionedBase
 from pydantic_ome_ngff.utils import (
     ArrayLike,
     ChunkedArrayLike,
@@ -184,7 +184,7 @@ def ensure_axis_types(axes: Sequence[Axis]) -> Sequence[Axis]:
     return axes
 
 
-class MultiscaleMetadata(StrictVersionedBase):
+class MultiscaleMetadata(VersionedBase):
     """
     Multiscale image metadata.
 
@@ -249,7 +249,7 @@ class MultiscaleMetadata(StrictVersionedBase):
         return self
 
 
-class GroupAttrs(BaseModel):
+class MultiscaleGroupAttrs(BaseModel):
     """
     A model of the required attributes of a Zarr group that implements OME-NGFF Multiscales metadata.
 
@@ -264,7 +264,7 @@ class GroupAttrs(BaseModel):
     multiscales: Annotated[tuple[MultiscaleMetadata, ...], Field(..., min_length=1)]
 
 
-class Group(GroupSpec[GroupAttrs, Union[ArraySpec, GroupSpec]]):
+class MultiscaleGroup(GroupSpec[MultiscaleGroupAttrs, Union[ArraySpec, GroupSpec]]):
     """
     A model of a Zarr group that implements OME-NGFF Multiscales metadata.
 
@@ -281,7 +281,7 @@ class Group(GroupSpec[GroupAttrs, Union[ArraySpec, GroupSpec]]):
     """
 
     @classmethod
-    def from_zarr(cls, node: zarr.Group) -> Group:
+    def from_zarr(cls, node: zarr.Group) -> MultiscaleGroup:
         """
         Create an instance of `Group` from a `node`, a `zarr.Group`. This method discovers Zarr arrays in the hierarchy rooted at `node` by inspecting the OME-NGFF
         multiscales metadata.
@@ -309,7 +309,7 @@ class Group(GroupSpec[GroupAttrs, Union[ArraySpec, GroupSpec]]):
             )
             raise KeyError(msg) from e
 
-        multi_meta = GroupAttrs(multiscales=multi_meta_maybe)
+        multi_meta = MultiscaleGroupAttrs(multiscales=multi_meta_maybe)
         members_tree_flat = {}
         for multiscale in multi_meta.multiscales:
             for dataset in multiscale.datasets:
@@ -426,11 +426,11 @@ class Group(GroupSpec[GroupAttrs, Union[ArraySpec, GroupSpec]]):
         )
         return cls(
             members=GroupSpec.from_flat(members_flat).members,
-            attributes=GroupAttrs(multiscales=(multimeta,)),
+            attributes=MultiscaleGroupAttrs(multiscales=(multimeta,)),
         )
 
     @model_validator(mode="after")
-    def check_arrays_exist(self) -> Group:
+    def check_arrays_exist(self) -> MultiscaleGroup:
         """
         Check that the arrays referenced in the `multiscales` metadata are actually contained in this group.
         """
@@ -457,7 +457,7 @@ class Group(GroupSpec[GroupAttrs, Union[ArraySpec, GroupSpec]]):
         return self
 
     @model_validator(mode="after")
-    def check_array_ndim(self) -> Group:
+    def check_array_ndim(self) -> MultiscaleGroup:
         """
         Check that all the arrays referenced by the `multiscales` metadata have dimensionality consistent with the
         `coordinateTransformations` metadata.
@@ -493,6 +493,19 @@ class Group(GroupSpec[GroupAttrs, Union[ArraySpec, GroupSpec]]):
                             raise ValueError(msg)
 
         return self
+
+
+# for backwards compatibility
+@deprecated(
+    "The `Group` class has been renamed to `MultiscaleGroup`. This class remains for backwards compatibility, but it will be removed. You should use `MultiscaleGroup`."
+)
+class Group(MultiscaleGroup): ...
+
+
+@deprecated(
+    "The `GroupAttrs` class has been renamed to `MultiscaleGroupAttrs`. This class remains for backwards compatibility, but it will be removed. You should use `MultiscaleGroupAttrs`."
+)
+class GroupAttrs(MultiscaleGroupAttrs): ...
 
 
 def normalize_chunks(

--- a/src/pydantic_ome_ngff/v04/plate.py
+++ b/src/pydantic_ome_ngff/v04/plate.py
@@ -10,7 +10,7 @@ from pydantic import (
 from pydantic_zarr.v2 import ArraySpec, GroupSpec
 
 from pydantic_ome_ngff.base import VersionedBase
-from pydantic_ome_ngff.v04 import well
+from pydantic_ome_ngff.v04.well import WellGroup
 from pydantic_ome_ngff.v04.base import version
 
 
@@ -52,15 +52,15 @@ class GroupAttrs(BaseModel):
     plate: PlateMetadata
 
 
-class Group(GroupSpec[GroupAttrs, well.Group | GroupSpec | ArraySpec]):
+class Group(GroupSpec[GroupAttrs, WellGroup | GroupSpec | ArraySpec]):
     @field_validator("members", mode="after")
     @classmethod
     def contains_well_group(
-        cls, members: Group | GroupSpec | ArraySpec
-    ) -> Group | GroupSpec | ArraySpec:
+        cls, members: WellGroup | GroupSpec | ArraySpec
+    ) -> WellGroup | GroupSpec | ArraySpec:
         """
         Check that .members contains a WellGroup
         """
-        if not any(isinstance(v, well.Group) for v in members.values()):
+        if not any(isinstance(v, WellGroup) for v in members.values()):
             raise ValidationError
         return members

--- a/src/pydantic_ome_ngff/v04/well.py
+++ b/src/pydantic_ome_ngff/v04/well.py
@@ -29,7 +29,9 @@ class GroupAttrs(BaseModel):
     well: WellMetadata
 
 
-class Group(GroupSpec[GroupAttrs, Union[multiscale.Group, GroupSpec, ArraySpec]]):
+class Group(
+    GroupSpec[GroupAttrs, Union[multiscale.MultiscaleGroup, GroupSpec, ArraySpec]]
+):
     @field_validator("members", mode="after")
     @classmethod
     def contains_multiscale_group(
@@ -38,6 +40,6 @@ class Group(GroupSpec[GroupAttrs, Union[multiscale.Group, GroupSpec, ArraySpec]]
         """
         Check that .members contains a MultiscaleGroup
         """
-        if not any(isinstance(v, multiscale.Group) for v in members.values()):
+        if not any(isinstance(v, multiscale.MultiscaleGroup) for v in members.values()):
             raise ValidationError
         return members

--- a/tests/v04/test_multiscales.py
+++ b/tests/v04/test_multiscales.py
@@ -12,9 +12,9 @@ from zarr.util import guess_chunks
 from pydantic_zarr.v2 import ArraySpec, GroupSpec
 from pydantic_ome_ngff.v04.multiscale import (
     MultiscaleMetadata,
-    GroupAttrs,
+    MultiscaleGroupAttrs,
     Dataset,
-    Group,
+    MultiscaleGroup,
 )
 
 from pydantic_ome_ngff.v04.transform import (
@@ -251,7 +251,7 @@ def test_transform_invalid_second_element(
 def test_multiscale_group_datasets_exist(
     default_multiscale: MultiscaleMetadata,
 ) -> None:
-    group_attrs = GroupAttrs(multiscales=(default_multiscale,))
+    group_attrs = MultiscaleGroupAttrs(multiscales=(default_multiscale,))
     good_items = {
         d.path: ArraySpec(
             shape=(1, 1, 1, 1),
@@ -260,7 +260,7 @@ def test_multiscale_group_datasets_exist(
         )
         for d in default_multiscale.datasets
     }
-    Group(attributes=group_attrs, members=good_items)
+    MultiscaleGroup(attributes=group_attrs, members=good_items)
 
     bad_items = {
         d.path + "x": ArraySpec(
@@ -283,11 +283,11 @@ def test_multiscale_group_datasets_exist(
             )
             for d in default_multiscale.datasets
         }
-        Group(attributes=group_attrs, members=bad_items)
+        MultiscaleGroup(attributes=group_attrs, members=bad_items)
 
 
 def test_multiscale_group_datasets_rank(default_multiscale: MultiscaleMetadata) -> None:
-    group_attrs = GroupAttrs(multiscales=(default_multiscale,))
+    group_attrs = MultiscaleGroupAttrs(multiscales=(default_multiscale,))
     good_items = {
         d.path: ArraySpec(
             shape=(1, 1, 1, 1),
@@ -296,7 +296,7 @@ def test_multiscale_group_datasets_rank(default_multiscale: MultiscaleMetadata) 
         )
         for d in default_multiscale.datasets
     }
-    Group(attributes=group_attrs, members=good_items)
+    MultiscaleGroup(attributes=group_attrs, members=good_items)
 
     # arrays with varying rank
     bad_items = {
@@ -318,7 +318,7 @@ def test_multiscale_group_datasets_rank(default_multiscale: MultiscaleMetadata) 
             )
             for idx, d in enumerate(default_multiscale.datasets)
         }
-        Group(attributes=group_attrs, members=bad_items)
+        MultiscaleGroup(attributes=group_attrs, members=bad_items)
 
     # arrays with rank that doesn't match the transform
     bad_items = {
@@ -331,7 +331,7 @@ def test_multiscale_group_datasets_rank(default_multiscale: MultiscaleMetadata) 
             d.path: ArraySpec(shape=(1,), dtype="uint8", chunks=(1,))
             for d in default_multiscale.datasets
         }
-        Group(attributes=group_attrs, members=bad_items)
+        MultiscaleGroup(attributes=group_attrs, members=bad_items)
 
 
 @pytest.mark.parametrize("name", [None, "foo"])
@@ -395,7 +395,7 @@ def test_from_arrays(
     else:
         order_expected = order
 
-    group = Group.from_arrays(
+    group = MultiscaleGroup.from_arrays(
         paths=paths,
         axes=axes,
         arrays=arrays,
@@ -447,7 +447,7 @@ def test_from_zarr_missing_metadata(
         f"{store}://{store_path}://{group.path}."
     )
     with pytest.raises(KeyError, match=match):
-        Group.from_zarr(group)
+        MultiscaleGroup.from_zarr(group)
 
 
 @pytest.mark.parametrize(
@@ -467,7 +467,7 @@ def test_from_zarr_missing_array(
     arrays = np.zeros((10, 10)), np.zeros((5, 5))
     group_path = "broken"
     arrays_names = ("s0", "s1")
-    group_model = Group.from_arrays(
+    group_model = MultiscaleGroup.from_arrays(
         arrays=arrays,
         axes=(Axis(name="x", type="space"), Axis(name="y", type="space")),
         paths=arrays_names,
@@ -484,7 +484,7 @@ def test_from_zarr_missing_array(
         "but no array was found there."
     )
     with pytest.raises(ValueError, match=match):
-        Group.from_zarr(broken_group)
+        MultiscaleGroup.from_zarr(broken_group)
 
     # put a group where the array should be
     broken_group.create_group(removed_array_path)
@@ -493,7 +493,7 @@ def test_from_zarr_missing_array(
         "but a group was found there instead."
     )
     with pytest.raises(ValueError, match=match):
-        Group.from_zarr(broken_group)
+        MultiscaleGroup.from_zarr(broken_group)
 
 
 def test_hashable(default_multiscale: MultiscaleMetadata) -> None:


### PR DESCRIPTION
Partially addresses concerns raised in #36. Renames `Group` and `Groupattrs` to `MultiscaleGroup` and `MultiscaleGroupAttrs`. Deprecated classes with the old names still exist, to support backwards compatibility. 

Tests are failing because this project still supports python 3.9, which has been widely dropped. A separate PR will drop python 3.9.