### PR TITLE
Skip serializing `None` for select fields

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -183,9 +183,6 @@ print(group_model.model_dump())
         'multiscales': (
             {
                 'version': '0.4',
-                'name': None,
-                'type': None,
-                'metadata': None,
                 'datasets': (
                     {
                         'path': 's0',
@@ -214,7 +211,6 @@ print(group_model.model_dump())
                     {'name': 'y', 'type': 'space', 'unit': 'nanometer'},
                     {'name': 'x', 'type': 'space', 'unit': 'nanometer'},
                 ),
-                'coordinateTransformations': None,
             },
         )
     },
@@ -272,9 +268,6 @@ print(stored_group.attrs.asdict())
     'multiscales': (
         {
             'version': '0.4',
-            'name': None,
-            'type': None,
-            'metadata': None,
             'datasets': (
                 {
                     'path': 's0',
@@ -297,7 +290,6 @@ print(stored_group.attrs.asdict())
                 {'name': 'y', 'type': 'space', 'unit': 'nanometer'},
                 {'name': 'x', 'type': 'space', 'unit': 'nanometer'},
             ),
-            'coordinateTransformations': None,
         },
     )
 }
@@ -366,9 +358,6 @@ print(group.model_dump())
         'multiscales': (
             {
                 'version': '0.4',
-                'name': None,
-                'type': None,
-                'metadata': None,
                 'datasets': (
                     {
                         'path': 's0',
@@ -397,7 +386,6 @@ print(group.model_dump())
                     {'name': 'y', 'type': 'space', 'unit': 'nanometer'},
                     {'name': 'x', 'type': 'space', 'unit': 'nanometer'},
                 ),
-                'coordinateTransformations': None,
             },
         )
     },
@@ -488,9 +476,6 @@ print(GroupOfMultiscales.from_zarr(zgroup).model_dump())
                 'multiscales': (
                     {
                         'version': '0.4',
-                        'name': None,
-                        'type': None,
-                        'metadata': None,
                         'datasets': (
                             {
                                 'path': 's0',
@@ -501,10 +486,9 @@ print(GroupOfMultiscales.from_zarr(zgroup).model_dump())
                             },
                         ),
                         'axes': (
-                            {'name': 'x', 'type': 'space', 'unit': None},
-                            {'name': 'y', 'type': 'space', 'unit': None},
+                            {'name': 'x', 'type': 'space'},
+                            {'name': 'y', 'type': 'space'},
                         ),
-                        'coordinateTransformations': None,
                     },
                 )
             },
@@ -519,7 +503,7 @@ print(GroupOfMultiscales.from_zarr(zgroup).model_dump())
                     'order': 'C',
                     'filters': None,
                     'dimension_separator': '/',
-                    'compressor': {'id': 'zstd', 'level': 3},
+                    'compressor': {'id': 'zstd', 'level': 3, 'checksum': False},
                 }
             },
         },
@@ -529,9 +513,6 @@ print(GroupOfMultiscales.from_zarr(zgroup).model_dump())
                 'multiscales': (
                     {
                         'version': '0.4',
-                        'name': None,
-                        'type': None,
-                        'metadata': None,
                         'datasets': (
                             {
                                 'path': 's0',
@@ -542,10 +523,9 @@ print(GroupOfMultiscales.from_zarr(zgroup).model_dump())
                             },
                         ),
                         'axes': (
-                            {'name': 'x', 'type': 'space', 'unit': None},
-                            {'name': 'y', 'type': 'space', 'unit': None},
+                            {'name': 'x', 'type': 'space'},
+                            {'name': 'y', 'type': 'space'},
                         ),
-                        'coordinateTransformations': None,
                     },
                 )
             },
@@ -560,7 +540,7 @@ print(GroupOfMultiscales.from_zarr(zgroup).model_dump())
                     'order': 'C',
                     'filters': None,
                     'dimension_separator': '/',
-                    'compressor': {'id': 'zstd', 'level': 3},
+                    'compressor': {'id': 'zstd', 'level': 3, 'checksum': False},
                 }
             },
         },

--- a/src/pydantic_ome_ngff/base.py
+++ b/src/pydantic_ome_ngff/base.py
@@ -18,21 +18,21 @@ class VersionedBase(pydantic.BaseModel):
     _version: str = "0.0"
 
 
-class NoneSkipBase(pydantic.BaseModel):
+class SkipNoneBase(pydantic.BaseModel):
     _skip_if_none: tuple[str, ...] = ()
 
     @pydantic.model_serializer(mode="wrap")
     def serialize(
         self: Self,
-        serializer: Callable[[NoneSkipBase], dict[str, Any]],
+        serializer: Callable[[SkipNoneBase], dict[str, Any]],
         info: pydantic.SerializationInfo,
     ) -> dict[str, Any]:
         return skip_none(self, serializer, info)
 
 
 def skip_none(
-    self: NoneSkipBase,
-    serializer: Callable[[NoneSkipBase], dict[str, Any]],
+    self: SkipNoneBase,
+    serializer: Callable[[SkipNoneBase], dict[str, Any]],
     info: pydantic.SerializationInfo,
 ) -> dict[str, Any]:
     """

--- a/src/pydantic_ome_ngff/base.py
+++ b/src/pydantic_ome_ngff/base.py
@@ -49,6 +49,11 @@ def skip_none(
         for key in info.exclude:
             out.pop(key, None)
 
+    if info.include is not None:
+        for key in tuple(out.keys()):
+            if key not in info.include:
+                out.pop(key)
+
     if info.exclude_none:
         for key, value in tuple(out.items()):
             if value is None:

--- a/src/pydantic_ome_ngff/v04/axis.py
+++ b/src/pydantic_ome_ngff/v04/axis.py
@@ -5,7 +5,7 @@ import warnings
 from enum import Enum
 
 
-from pydantic_ome_ngff.base import FrozenBase, NoneSkipBase
+from pydantic_ome_ngff.base import FrozenBase, SkipNoneBase
 from pydantic_ome_ngff.v04.base import version
 
 
@@ -123,7 +123,7 @@ def check_type_unit(model: Axis) -> Axis:
     return model
 
 
-class Axis(NoneSkipBase, FrozenBase):
+class Axis(SkipNoneBase, FrozenBase):
     """
     Axis metadata.
 

--- a/src/pydantic_ome_ngff/v04/axis.py
+++ b/src/pydantic_ome_ngff/v04/axis.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+from typing import Literal
 import warnings
 from enum import Enum
 
-from pydantic_ome_ngff.base import StrictVersionedBase
+
+from pydantic_ome_ngff.base import FrozenBase, NoneSkipBase
 from pydantic_ome_ngff.v04.base import version
 
 
@@ -121,7 +123,7 @@ def check_type_unit(model: Axis) -> Axis:
     return model
 
 
-class Axis(StrictVersionedBase):
+class Axis(NoneSkipBase, FrozenBase):
     """
     Axis metadata.
 
@@ -129,16 +131,22 @@ class Axis(StrictVersionedBase):
 
     Attributes
     ----------
-
+    _version: Literal['0.4']
+        The current version of this metadata.
+    _skip_if_none: tuple[str,...], default=("type", "unit")
+        Names of fields that will not be serialized if they are None.
     name: str
         The name for this axis.
-    type: str | None
+    type: str | None = None
         The type for this axis, e.g. "space".
+        If this is set to None, it will not be serialized.
     unit: str | None
         The unit of measure associated with the interval defined by this axis.
+        If this is set to None, it will not be serialized.
     """
 
     _version = version
+    _skip_if_none: tuple[Literal["type"], Literal["unit"]] = "type", "unit"
     name: str
     type: str | None = None
     unit: str | None = None

--- a/src/pydantic_ome_ngff/v04/multiscale.py
+++ b/src/pydantic_ome_ngff/v04/multiscale.py
@@ -20,7 +20,7 @@ from zarr.errors import ArrayNotFoundError, ContainsGroupError
 from zarr.util import guess_chunks
 
 import pydantic_ome_ngff.v04.transform as tx
-from pydantic_ome_ngff.base import FrozenBase, NoneSkipBase, VersionedBase
+from pydantic_ome_ngff.base import FrozenBase, SkipNoneBase, VersionedBase
 from pydantic_ome_ngff.utils import (
     ArrayLike,
     ChunkedArrayLike,
@@ -184,7 +184,7 @@ def ensure_axis_types(axes: Sequence[Axis]) -> Sequence[Axis]:
     return axes
 
 
-class MultiscaleMetadata(VersionedBase, FrozenBase, NoneSkipBase):
+class MultiscaleMetadata(VersionedBase, FrozenBase, SkipNoneBase):
     """
     Multiscale image metadata.
 

--- a/src/pydantic_ome_ngff/v04/multiscale.py
+++ b/src/pydantic_ome_ngff/v04/multiscale.py
@@ -20,7 +20,7 @@ from zarr.errors import ArrayNotFoundError, ContainsGroupError
 from zarr.util import guess_chunks
 
 import pydantic_ome_ngff.v04.transform as tx
-from pydantic_ome_ngff.base import StrictBase, VersionedBase
+from pydantic_ome_ngff.base import FrozenBase, NoneSkipBase, VersionedBase
 from pydantic_ome_ngff.utils import (
     ArrayLike,
     ChunkedArrayLike,
@@ -75,7 +75,7 @@ def ensure_transforms_length(
     return transforms
 
 
-class Dataset(StrictBase):
+class Dataset(FrozenBase):
     """
     A single entry in the `multiscales.datasets` list.
 
@@ -184,7 +184,7 @@ def ensure_axis_types(axes: Sequence[Axis]) -> Sequence[Axis]:
     return axes
 
 
-class MultiscaleMetadata(VersionedBase):
+class MultiscaleMetadata(VersionedBase, FrozenBase, NoneSkipBase):
     """
     Multiscale image metadata.
 
@@ -209,6 +209,12 @@ class MultiscaleMetadata(VersionedBase):
     """
 
     _version = version
+    _skip_if_none: tuple[
+        Literal["name"],
+        Literal["coordinateTransformations"],
+        Literal["type"],
+        Literal["metadata"],
+    ] = ("name", "coordinateTransformations", "type", "metadata")
     version: Any = version
     name: Any = None
     type: Any = None

--- a/src/pydantic_ome_ngff/v04/transform.py
+++ b/src/pydantic_ome_ngff/v04/transform.py
@@ -2,13 +2,13 @@ from __future__ import annotations
 
 from typing import Annotated, Literal, Sequence
 
-from pydantic_ome_ngff.base import StrictBase
+from pydantic_ome_ngff.base import FrozenBase
 
 from pydantic import BeforeValidator
 from pydantic_ome_ngff.utils import ArrayLike, listify_numpy
 
 
-class Identity(StrictBase):
+class Identity(FrozenBase):
     """
     An identity transform. It has no parameters other than `type`, and no valid use according to the spec.
 
@@ -29,7 +29,7 @@ class Identity(StrictBase):
         raise NotImplementedError
 
 
-class PathTranslation(StrictBase):
+class PathTranslation(FrozenBase):
     """
     A translation transformation with a `path` field. The spec states that `path` should resolve to "binary data".
 
@@ -52,7 +52,7 @@ class PathTranslation(StrictBase):
         raise NotImplementedError
 
 
-class PathScale(StrictBase):
+class PathScale(FrozenBase):
     """
     A scaling transformation with a `path` field. The spec states that `path` should resolve to "binary data".
 
@@ -74,7 +74,7 @@ class PathScale(StrictBase):
         raise NotImplementedError
 
 
-class VectorTranslation(StrictBase):
+class VectorTranslation(FrozenBase):
     """
     A translation transformation defined by a sequence of numbers.
 
@@ -96,7 +96,7 @@ class VectorTranslation(StrictBase):
         return ndim(self)
 
 
-class VectorScale(StrictBase):
+class VectorScale(FrozenBase):
     """
     A scaling transformation defined by a sequence of numbers.
 

--- a/tests/latest/test_multiscales.py
+++ b/tests/latest/test_multiscales.py
@@ -1,5 +1,4 @@
 from __future__ import annotations
-from typing import List, Optional, Tuple
 from pydantic import ValidationError
 import pytest
 import jsonschema as jsc
@@ -128,7 +127,7 @@ def test_multiscale_unique_axis_names() -> None:
         ("space", "channel", "space", "channel"),
     ],
 )
-def test_multiscale_space_axes_last(axis_types: List[Optional[str]]) -> None:
+def test_multiscale_space_axes_last(axis_types: list[str | None]) -> None:
     units_map = {"space": "meter", "time": "second"}
     axes: list[Axis] = []
     for idx, t in enumerate(axis_types):
@@ -241,7 +240,7 @@ def test_coordinate_transforms_invalid_ndims() -> None:
     ],
 )
 def test_coordinate_transforms_invalid_length(
-    transforms: List[Transform],
+    transforms: list[Transform],
 ) -> None:
     with pytest.raises(
         ValidationError, match=f"after validation, not {len(transforms)}"
@@ -263,7 +262,7 @@ def test_coordinate_transforms_invalid_length(
     ],
 )
 def test_coordinate_transforms_invalid_first_element(
-    transforms: Tuple[Transform, Transform],
+    transforms: tuple[Transform, Transform],
 ) -> None:
     with pytest.raises(
         ValidationError,
@@ -282,7 +281,7 @@ def test_coordinate_transforms_invalid_first_element(
     ),
 )
 def test_coordinate_transforms_invalid_second_element(
-    transforms: Tuple[Transform, Transform],
+    transforms: tuple[Transform, Transform],
 ) -> None:
     with pytest.raises(
         ValidationError,

--- a/tests/latest/test_multiscales.py
+++ b/tests/latest/test_multiscales.py
@@ -33,18 +33,8 @@ def multi_meta() -> MultiscaleMetadata:
         Dataset(
             path=f"path{idx}",
             coordinateTransformations=(
-                VectorScale(
-                    scale=[
-                        1,
-                    ]
-                    * rank
-                ),
-                VectorTranslation(
-                    translation=[
-                        0,
-                    ]
-                    * rank
-                ),
+                VectorScale(scale=(1,) * rank),
+                VectorTranslation(translation=(0,) * rank),
             ),
         )
         for idx in range(num_datasets)
@@ -54,14 +44,7 @@ def multi_meta() -> MultiscaleMetadata:
         name="foo",
         axes=axes,
         datasets=datasets,
-        coordinateTransformations=(
-            VectorScale(
-                scale=[
-                    1,
-                ]
-                * rank
-            ),
-        ),
+        coordinateTransformations=(VectorScale(scale=(1,) * rank),),
     )
     return multi
 
@@ -83,8 +66,8 @@ def test_multiscale_unique_axis_names() -> None:
         Dataset(
             path="path",
             coordinateTransformations=(
-                VectorScale(scale=[1, 1, 1]),
-                VectorTranslation(translation=[0, 0, 0]),
+                VectorScale(scale=(1, 1, 1)),
+                VectorTranslation(translation=(0, 0, 0)),
             ),
         )
     ]
@@ -93,7 +76,7 @@ def test_multiscale_unique_axis_names() -> None:
         name="foo",
         axes=axes,
         datasets=datasets,
-        coordinateTransformations=(VectorScale(scale=[1, 1, 1]),),
+        coordinateTransformations=(VectorScale(scale=(1, 1, 1)),),
     )
 
     # make axis names collide
@@ -105,8 +88,8 @@ def test_multiscale_unique_axis_names() -> None:
         Dataset(
             path="path",
             coordinateTransformations=(
-                VectorScale(scale=[1, 1, 1]),
-                VectorTranslation(translation=[0, 0, 0]),
+                VectorScale(scale=(1, 1, 1)),
+                VectorTranslation(translation=(0, 0, 0)),
             ),
         )
     ]
@@ -116,7 +99,7 @@ def test_multiscale_unique_axis_names() -> None:
             name="foo",
             axes=axes,
             datasets=datasets,
-            coordinateTransformations=(VectorScale(scale=[1, 1, 1]),),
+            coordinateTransformations=(VectorScale(scale=(1, 1, 1)),),
         )
 
 
@@ -142,18 +125,8 @@ def test_multiscale_space_axes_last(axis_types: list[str | None]) -> None:
         Dataset(
             path="path",
             coordinateTransformations=(
-                VectorScale(
-                    scale=[
-                        1,
-                    ]
-                    * rank
-                ),
-                VectorTranslation(
-                    translation=[
-                        0,
-                    ]
-                    * rank
-                ),
+                VectorScale(scale=(1,) * rank),
+                VectorTranslation(translation=(0,) * rank),
             ),
         )
     ]
@@ -163,14 +136,7 @@ def test_multiscale_space_axes_last(axis_types: list[str | None]) -> None:
             name="foo",
             axes=axes,
             datasets=datasets,
-            coordinateTransformations=(
-                VectorScale(
-                    scale=[
-                        1,
-                    ]
-                    * rank
-                ),
-            ),
+            coordinateTransformations=(VectorScale(scale=(1,) * rank),),
         )
 
 
@@ -182,18 +148,8 @@ def test_multiscale_axis_length(num_axes: int) -> None:
         Dataset(
             path="path",
             coordinateTransformations=(
-                VectorScale(
-                    scale=[
-                        1,
-                    ]
-                    * rank
-                ),
-                VectorTranslation(
-                    translation=[
-                        0,
-                    ]
-                    * rank
-                ),
+                VectorScale(scale=(1,) * rank),
+                VectorTranslation(translation=(0,) * rank),
             ),
         )
     ]
@@ -202,14 +158,7 @@ def test_multiscale_axis_length(num_axes: int) -> None:
             name="foo",
             axes=axes,
             datasets=datasets,
-            coordinateTransformations=(
-                VectorScale(
-                    scale=[
-                        1,
-                    ]
-                    * rank
-                ),
-            ),
+            coordinateTransformations=(VectorScale(scale=(1,) * rank),),
         )
 
 
@@ -369,18 +318,8 @@ def default_multiscale() -> MultiscaleMetadata:
         Dataset(
             path=f"path{idx}",
             coordinateTransformations=(
-                VectorScale(
-                    scale=[
-                        1,
-                    ]
-                    * rank
-                ),
-                VectorTranslation(
-                    translation=[
-                        0,
-                    ]
-                    * rank
-                ),
+                VectorScale(scale=(1,) * rank),
+                VectorTranslation(translation=(0,) * rank),
             ),
         )
         for idx in range(num_datasets)
@@ -390,13 +329,6 @@ def default_multiscale() -> MultiscaleMetadata:
         name="foo",
         axes=axes,
         datasets=datasets,
-        coordinateTransformations=(
-            VectorScale(
-                scale=[
-                    1,
-                ]
-                * rank
-            ),
-        ),
+        coordinateTransformations=(VectorScale(scale=(1,) * rank),),
     )
     return multi

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,6 +1,6 @@
 import pytest
 import pydantic
-from pydantic_ome_ngff.base import FrozenBase, VersionedBase, NoneSkipBase
+from pydantic_ome_ngff.base import FrozenBase, VersionedBase, SkipNoneBase
 
 
 def test_frozen_base() -> None:
@@ -19,7 +19,7 @@ def test_versioned_base() -> None:
 
 
 def test_noneskipbase() -> None:
-    class X(NoneSkipBase):
+    class X(SkipNoneBase):
         _skip_if_none = ("a", "b")
         a: int | None
         b: int

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,0 +1,31 @@
+import pytest
+import pydantic
+from pydantic_ome_ngff.base import FrozenBase, VersionedBase, NoneSkipBase
+
+
+def test_frozen_base() -> None:
+    class X(FrozenBase):
+        x: int
+
+    f = X(x=10)
+    with pytest.raises(pydantic.ValidationError, match="Instance is frozen"):
+        f.x = 100  # type: ignore
+
+
+def test_versioned_base() -> None:
+    class X(VersionedBase): ...
+
+    assert X()._version == "0.0"
+
+
+def test_noneskipbase() -> None:
+    class X(NoneSkipBase):
+        _skip_if_none = ("a", "b")
+        a: int | None
+        b: int
+        c: int
+
+    instance = X(a=None, b=10, c=10)
+    assert instance.model_dump() == {"b": 10, "c": 10}
+    assert instance.model_dump(include={"b"}) == {"b": 10}
+    assert instance.model_dump(exclude={"b"}) == {"c": 10}

--- a/tests/v04/test_axis.py
+++ b/tests/v04/test_axis.py
@@ -1,0 +1,7 @@
+from pydantic_ome_ngff.v04 import Axis
+
+
+def test_axis_serialization() -> None:
+    ax = Axis(name="foo", unit=None, type=None)
+    assert ax.model_dump() == {"name": ax.name}
+    assert ax.model_dump(exclude={"name"}) == {}

--- a/tests/v04/test_label.py
+++ b/tests/v04/test_label.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import List, Literal
+from typing import Literal
 import pytest
 from pydantic import ValidationError
 from pydantic_ome_ngff.v04 import version as NGFF_VERSION
@@ -8,7 +8,7 @@ from pydantic_ome_ngff.v04.label import Color, ImageLabel, Property
 
 
 @pytest.mark.parametrize("version", (None, "0.4"))
-def test_imagelabel(version: Literal["0.4"] | None):
+def test_imagelabel(version: Literal["0.4"] | None) -> None:
     color = Color(label_value=1, rgba=[0, 0, 0, 0])
     model = ImageLabel(colors=[color], version=version)
     dumped = model.model_dump()
@@ -19,7 +19,7 @@ def test_imagelabel(version: Literal["0.4"] | None):
         assert dumped["version"] == NGFF_VERSION
 
 
-def test_properties_colors_match():
+def test_properties_colors_match() -> None:
     color = Color(label_value=0, rgba=(0, 0, 0, 0))
     prop = Property(label_value=1)
 
@@ -46,7 +46,7 @@ def test_imagelabel_version(version: str) -> None:
         ],
     ),
 )
-def test_imagelabel_colors(colors: List[Color] | None):
+def test_imagelabel_colors(colors: list[Color] | None) -> None:
     if colors is None:
         with pytest.warns(UserWarning):
             ImageLabel(colors=colors)

--- a/tests/v04/test_utils.py
+++ b/tests/v04/test_utils.py
@@ -20,7 +20,7 @@ from pydantic_ome_ngff.v04.utils import (
 @pytest.mark.parametrize(
     "ndim, scale", ((3, (1, 2, 3)), (3, None), (2, (1, 2)), (2, None))
 )
-def test_normalize_scale(ndim: int, scale: tuple[int, int, int] | None):
+def test_normalize_scale(ndim: int, scale: tuple[int, int, int] | None) -> None:
     normalized = normalize_scale(ndim=ndim, param=scale)
     if scale is None:
         assert normalized == (1,) * ndim
@@ -31,7 +31,7 @@ def test_normalize_scale(ndim: int, scale: tuple[int, int, int] | None):
 @pytest.mark.parametrize(
     "ndim, trans", ((3, (1, 2, 3)), (3, None), (2, (1, 2)), (2, None))
 )
-def test_normalize_translation(ndim: int, trans: tuple[int, int, int] | None):
+def test_normalize_translation(ndim: int, trans: tuple[int, int, int] | None) -> None:
     normalized = normalize_translation(ndim=ndim, param=trans)
     if trans is None:
         assert normalized == (0,) * ndim
@@ -48,7 +48,7 @@ def test_transform_coordinate_transformations(
     old_trans: Literal["auto"] | None,
     in_scale: Literal["auto"] | None,
     in_trans: Literal["auto"] | None,
-):
+) -> None:
     old_ctx: tuple[VectorScale] | tuple[VectorScale, VectorTranslation] = ()
     old_scale = tuple(range(ndim))
     old_ctx += (VectorScale(scale=old_scale),)
@@ -147,7 +147,7 @@ def test_transform_dataset(
 )
 def test_transform_multiscale_metadata(
     ctx: None | tuple[VectorScale] | tuple[VectorScale, VectorTranslation],
-):
+) -> None:
     scale = (2, 2)
     trans = (0.5, 0.5)
     datasets = (
@@ -172,7 +172,7 @@ def test_transform_multiscale_metadata(
 @pytest.mark.parametrize("ctx", (None, "auto"))
 def test_transpose_axes_multiscale(
     order: tuple[int, ...] | tuple[str, ...], ctx: Literal["auto"] | None
-):
+) -> None:
     axes = {k: Axis(type="space", name=k) for k in ("x", "y", "z")}
     axes_tuple = tuple(axes.values())
     dataset = Dataset(
@@ -224,7 +224,7 @@ def test_transpose_axes_multiscale(
         (0, 2, 1),
     ),
 )
-def test_transpose_axes_dataset(order: tuple[int, int, int]):
+def test_transpose_axes_dataset(order: tuple[int, int, int]) -> None:
     dataset = Dataset(
         path="foo",
         coordinateTransformations=(


### PR DESCRIPTION
The spec lists a lot of optional metadata fields, like `axis.{type, unit}`, `multiscales.{coordinateTransformations, name, metadata}` etc. Previously, if these fields were `None`, then they were serialized to JSON as `null`, which might not match the expectations of consumers. 

In the case of `multiscales.coordinateTransformations`, `null` is not an allowed value and so this was a genuine spec violation. But `multiscales.metadata` is untyped AND optional, and so `null` could be a valid value for that attribute, but leaving it unset is also an option.

So the problem here is that specific fields of the pydantic models which model these metadata data structures should exclude certain fields from serialization if the value for those fields is `None`. To solve the problem, this PR adds a new base class for metadata (`SkipNoneBase`) that uses a class attribute `_skip_if_none` to represent the names of fields that should be skipped from serialization if they are `None`. During serialization, the `_skip_if_none` attribute is checked, and any field name that appears in that list will be omitted from serialization. I make a bit of an effort to handle some of the keyword arguments to `model_dump` in this custom serializer, but it's not clear how the semantics of `exclude_none` would work here.

I'm also making some of the classes that were previously strict (i.e., no extra keys allowed) non-strict. 