### PR TITLE
allow dtype-like arguments to from_array_props

### DIFF
--- a/src/pydantic_ome_ngff/utils.py
+++ b/src/pydantic_ome_ngff/utils.py
@@ -8,6 +8,7 @@ import numpy as np
 if TYPE_CHECKING:
     from collections.abc import Hashable, Iterable
     from typing import Any
+
     from zarr.storage import BaseStore
 
 
@@ -49,5 +50,4 @@ def get_path(store: BaseStore) -> str:
     if hasattr(store, "path"):
         return store.path
 
-    else:
-        return ""
+    return ""

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING
 import numpy as np
 
 if TYPE_CHECKING:
-    from typing import Any, List
+    from typing import Any
 
 import pytest
 
@@ -15,7 +15,7 @@ from pydantic_ome_ngff.utils import duplicates, listify_numpy
 @pytest.mark.parametrize(
     "data", [[0], [0, 1, 1, 1, 2], ["a", "a", "b", "b", "c", "c", "d"]]
 )
-def test_duplicates(data: List[Any]) -> None:
+def test_duplicates(data: list[Any]) -> None:
     dupes = duplicates(data)
     for key, value in dupes.items():
         assert data.count(key) == value

--- a/tests/v04/test_transform.py
+++ b/tests/v04/test_transform.py
@@ -1,7 +1,4 @@
 from __future__ import annotations
-
-from typing import Tuple, Type
-
 import pytest
 
 from pydantic_ome_ngff.v04.transform import (
@@ -24,7 +21,7 @@ from pydantic_ome_ngff.v04.transform import (
     ),
 )
 def test_scale_translation(
-    scale: Tuple[int, ...], translation: Tuple[int, ...]
+    scale: tuple[int, ...], translation: tuple[int, ...]
 ) -> None:
     if len(scale) == len(translation):
         result = scale_translation(scale=scale, translation=translation)
@@ -70,7 +67,7 @@ def test_ensure_dimensionality(
 @pytest.mark.parametrize("num_dims", ((1, 3, 5)))
 @pytest.mark.parametrize("transform", [VectorTranslation, VectorScale])
 def test_ndim(
-    num_dims: int, transform: Type[VectorTranslation] | Type[VectorScale]
+    num_dims: int, transform: type[VectorTranslation] | type[VectorScale]
 ) -> None:
     if transform == VectorScale:
         params = {"scale": (1,) * num_dims}


### PR DESCRIPTION
- allows dtype-like strings to `from_array_props`
- fixes a bug where the `order` was default to `auto` in `from_array_props`